### PR TITLE
Adiciona função que altera caracteres inválidos

### DIFF
--- a/src/components/Aula.vue
+++ b/src/components/Aula.vue
@@ -3,7 +3,7 @@
     <div
       class="box"
       :ref="'.' + identifier"
-      v-bind:class="[aula.disciplina, aula.turma, { 'box-hover': isMouseOver }, { 'ativado': isActive } ]"
+      v-bind:class="[this.parseDiscipline(aula.disciplina), aula.turma, { 'box-hover': isMouseOver }, { 'ativado': isActive } ]"
       @mouseenter="onMouseOver('enter')"
       @mouseleave="onMouseOver('leave')"
       @click="toggleState()"
@@ -28,7 +28,7 @@ export default {
   updated: function() {
     this.$nextTick(function() {
       let bothElements = document.querySelectorAll(
-        `.${this.aula.disciplina}.${this.aula.turma}`
+        `.${this.parseDiscipline(this.aula.disciplina)}.${this.aula.turma}`
       );
 
       for (let elm of bothElements) {
@@ -91,7 +91,10 @@ export default {
       if (this.isActive) {
         return this.addDisciplineIfNotExists();
       }
-      return this.removeDicipline();
+      return this.removeDiscipline();
+    },
+    parseDiscipline(discipline) {
+      return discipline.replace('/', '_');
     },
     addDisciplineIfNotExists() {
       if (this.haveDisciplineInStore()) {
@@ -112,7 +115,7 @@ export default {
         JSON.parse(window.localStorage.getItem("disciplinesIdentifier")) || []
       );
     },
-    removeDicipline() {
+    removeDiscipline() {
       return this.getStoreDisciplineIdentifier().filter(
         discipline => discipline !== this.identifier
       );

--- a/src/components/Aula.vue
+++ b/src/components/Aula.vue
@@ -2,7 +2,7 @@
     <div class="aula">
         <div
             class="box"
-            :ref="'.' + identifier"
+            :ref="`.${identifier}`.replace('/', '_')"
             v-bind:class="[aula.disciplina, aula.turma, { 'ativado': isActive }]" 
             @click="toggleState()"
             @click.right="showDetails = true"

--- a/src/components/Aula.vue
+++ b/src/components/Aula.vue
@@ -3,7 +3,7 @@
     <div
       class="box"
       :ref="'.' + identifier"
-      v-bind:class="[this.parseDiscipline(aula.disciplina), aula.turma, { 'box-hover': isMouseOver }, { 'ativado': isActive } ]"
+      v-bind:class="[this.changeInvalidCharacters(aula.disciplina), aula.turma, { 'box-hover': isMouseOver }, { 'ativado': isActive } ]"
       @mouseenter="onMouseOver('enter')"
       @mouseleave="onMouseOver('leave')"
       @click="toggleState()"
@@ -28,7 +28,9 @@ export default {
   updated: function() {
     this.$nextTick(function() {
       let bothElements = document.querySelectorAll(
-        `.${this.parseDiscipline(this.aula.disciplina)}.${this.aula.turma}`
+        `.${this.changeInvalidCharacters(this.aula.disciplina)}.${
+          this.aula.turma
+        }`
       );
 
       for (let elm of bothElements) {
@@ -68,7 +70,9 @@ export default {
   },
   computed: {
     identifier() {
-      return `${this.aula.disciplina}.${this.aula.turma}`.replace('/', '_');
+      return this.changeInvalidCharacters(
+        `${this.aula.disciplina}.${this.aula.turma}`
+      );
     }
   },
   methods: {
@@ -92,9 +96,6 @@ export default {
         return this.addDisciplineIfNotExists();
       }
       return this.removeDiscipline();
-    },
-    parseDiscipline(discipline) {
-      return discipline.replace('/', '_');
     },
     addDisciplineIfNotExists() {
       if (this.haveDisciplineInStore()) {
@@ -126,6 +127,9 @@ export default {
         "disciplinesIdentifier",
         JSON.stringify(disciplinesIdentifier)
       );
+    },
+    changeInvalidCharacters(string) {
+      return string.replace("/", "_");
     }
   }
 };

--- a/src/components/Aula.vue
+++ b/src/components/Aula.vue
@@ -2,7 +2,7 @@
   <div class="aula">
     <div
       class="box"
-      :ref="`.${identifier}`.replace('/', '_')"
+      :ref="'.' + identifier"
       v-bind:class="[aula.disciplina, aula.turma, { 'box-hover': isMouseOver }, { 'ativado': isActive } ]"
       @mouseenter="onMouseOver('enter')"
       @mouseleave="onMouseOver('leave')"
@@ -68,7 +68,7 @@ export default {
   },
   computed: {
     identifier() {
-      return `${this.aula.disciplina}.${this.aula.turma}`;
+      return `${this.aula.disciplina}.${this.aula.turma}`.replace('/', '_');
     }
   },
   methods: {


### PR DESCRIPTION
Fixes #103. 
As matérias que contém caracteres que não podem ser usado em nomes de classe (no caso, `irc/lirc`) quebravam o código, que depende do `querySelector`. A função substitui a barra `/` por um `_`.