### PR TITLE
Corrige hover ao desmarcar disciplina

### DIFF
--- a/src/components/Aula.vue
+++ b/src/components/Aula.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="aula" v-if="aula.visivel || aula.ativado">
+  <div class="aula" v-if="checkVisibility()">
     <div
       class="box" v-bind:class="[ { 'box-hover': aula.ativaHover }, { 'ativado': aula.ativado } ]"
       @mouseenter="onMouseOver('enter')" @mouseleave="onMouseOver('leave')"
@@ -33,6 +33,13 @@ export default {
       this.$store.commit('setAulaAtivado', this.aula.identifier);
       localstorage.updateStorage(this.aula);
     },
+    checkVisibility() {
+      if(this.aula.visivel || this.aula.ativado) return true;
+      else {
+        this.onMouseOver("leave");
+        return false;
+      }
+    }
   }
 };
 </script>


### PR DESCRIPTION
Para reproduzir esse problema:
1 - Marcar uma disciplina.
2 - Selecionar um dos filtros que essa disciplina não pertence.
3 - Desmarcar a disciplina.
4 - Remover os filtros.

![image](https://user-images.githubusercontent.com/15989443/73714150-c9cc6d80-46ee-11ea-8e87-8a6186c70b68.png)
